### PR TITLE
Switch task storage to async fs API

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,42 +8,43 @@ const TASK_FILE = process.env.TASK_FILE || path.join(__dirname, 'tasks.txt');
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
-function loadTasks() {
+async function loadTasks() {
   try {
-    const data = fs.readFileSync(TASK_FILE, 'utf8');
+    const data = await fs.promises.readFile(TASK_FILE, 'utf8');
     return data.split(/\r?\n/).filter(t => t);
   } catch (err) {
     return [];
   }
 }
 
-function saveTasks(tasks) {
-  fs.writeFileSync(TASK_FILE, tasks.join('\n'), 'utf8');
+async function saveTasks(tasks) {
+  await fs.promises.writeFile(TASK_FILE, tasks.join('\n'), 'utf8');
 }
 
-app.get('/tasks', (req, res) => {
-  res.json(loadTasks());
+app.get('/tasks', async (req, res) => {
+  const tasks = await loadTasks();
+  res.json(tasks);
 });
 
-app.post('/tasks', (req, res) => {
-  const tasks = loadTasks();
+app.post('/tasks', async (req, res) => {
+  const tasks = await loadTasks();
   const { task } = req.body;
   if (typeof task !== 'string' || !task.trim()) {
     return res.status(400).json({ error: 'invalid task' });
   }
   tasks.push(task.trim());
-  saveTasks(tasks);
+  await saveTasks(tasks);
   res.status(201).json({ message: 'task added' });
 });
 
-app.delete('/tasks/:index', (req, res) => {
-  const tasks = loadTasks();
+app.delete('/tasks/:index', async (req, res) => {
+  const tasks = await loadTasks();
   const idx = parseInt(req.params.index, 10);
   if (isNaN(idx) || idx < 0 || idx >= tasks.length) {
     return res.status(400).json({ error: 'invalid index' });
   }
   tasks.splice(idx, 1);
-  saveTasks(tasks);
+  await saveTasks(tasks);
   res.json({ message: 'task deleted' });
 });
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const fsp = fs.promises;
 const path = require('path');
 const os = require('os');
 const request = require('supertest');
@@ -9,13 +10,13 @@ fs.writeFileSync(tmpFile, '', 'utf8');
 
 const app = require('../server');
 
-afterAll(() => {
-  fs.unlinkSync(tmpFile);
+afterAll(async () => {
+  await fsp.unlink(tmpFile);
   delete process.env.TASK_FILE;
 });
 
-beforeEach(() => {
-  fs.writeFileSync(tmpFile, '', 'utf8');
+beforeEach(async () => {
+  await fsp.writeFile(tmpFile, '', 'utf8');
 });
 
 describe('Todo API', () => {


### PR DESCRIPTION
## Summary
- migrate `loadTasks`/`saveTasks` to use `fs.promises`
- convert Express routes to async/await
- update server tests for async setup/teardown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ea25e49483208ffb2a9e31d69718