### PR TITLE
Allow custom port setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ npm install
 npm start
 ```
 
-The server runs on <http://localhost:3000> and serves the HTML frontend from the `public/` directory. Use the page to add or delete tasks.
+By default the server runs on <http://localhost:3000>. To use a different port, set the `PORT` environment variable:
+
+```bash
+PORT=4000 npm start
+```
+
+The app serves the HTML frontend from the `public/` directory. Use the page to add or delete tasks.
 
 ## File overview
 

--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 const TASK_FILE = process.env.TASK_FILE || path.join(__dirname, 'tasks.txt');
 
 app.use(express.json());


### PR DESCRIPTION
## Summary
- make server port configurable via `PORT` environment variable
- document how to run on a different port in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ea284c548320aa1806069609c2ca