### PR TITLE
Add task update endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -47,6 +47,21 @@ app.delete('/tasks/:index', (req, res) => {
   res.json({ message: 'task deleted' });
 });
 
+app.put('/tasks/:index', (req, res) => {
+  const tasks = loadTasks();
+  const idx = parseInt(req.params.index, 10);
+  const { task } = req.body;
+  if (isNaN(idx) || idx < 0 || idx >= tasks.length) {
+    return res.status(400).json({ error: 'invalid index' });
+  }
+  if (typeof task !== 'string' || !task.trim()) {
+    return res.status(400).json({ error: 'invalid task' });
+  }
+  tasks[idx] = task.trim();
+  saveTasks(tasks);
+  res.json({ message: 'task updated' });
+});
+
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Server running on http://localhost:${PORT}`);

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -48,4 +48,17 @@ describe('Todo API', () => {
     const res = await request(app).delete('/tasks/5');
     expect(res.statusCode).toBe(400);
   });
+
+  test('PUT /tasks/:index updates a task', async () => {
+    await request(app).post('/tasks').send({ task: 'Old' });
+    const resUpdate = await request(app).put('/tasks/0').send({ task: 'New' });
+    expect(resUpdate.statusCode).toBe(200);
+    const res = await request(app).get('/tasks');
+    expect(res.body).toEqual(['New']);
+  });
+
+  test('PUT /tasks/:index invalid index returns 400', async () => {
+    const res = await request(app).put('/tasks/3').send({ task: 'Bad' });
+    expect(res.statusCode).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `PUT /tasks/:index` to edit existing tasks
- validate index and task string
- test updating a task and invalid indices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ea28da148320a32ceb9bb57d306d